### PR TITLE
Upgrade to run-queue w/ LICENSE

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "fs-write-stream-atomic": "^1.0.8",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.5.4",
-    "run-queue": "^1.0.3"
+    "run-queue": "^2.0.0"
   },
   "devDependencies": {
     "standard": "^8.6.0",


### PR DESCRIPTION
run-queue 1.0.3 and 2.0.0 is 100% compatible