### PR TITLE
build: update mkdirp to 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "copy-concurrently": "^1.0.0",
     "aproba": "^1.1.1",
     "fs-write-stream-atomic": "^1.0.8",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.4",
     "rimraf": "^2.5.4",
     "run-queue": "^1.0.3"
   },
   "devDependencies": {
     "standard": "^8.6.0",
     "tacks": "^1.2.6",
-    "tap": "^10.1.1"
+    "tap": "^7.1.2"
   },
   "files": [
     "move.js",


### PR DESCRIPTION
mkdirp is using a deprecated version of minimist https://github.com/substack/node-mkdirp/issues/166

Prototype pollution in minimist
https://github.com/advisories/GHSA-vh95-rmgr-6w4m
